### PR TITLE
Fix README.md instructions to match current structure of project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,10 @@ project/metals.sbt
 project/project/
 project/target/
 target/
+*/project/build.properties
+*/project/project
+*/project/target
+*/target
 
 # eclipse
 build/

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ To learn about each quickstart, we have a dedicated article about it at the ZIO 
 First, open the console and clone the project using `git` (or you can simply download the project) and then to the directory of the quickstart you want to run, e.g. `zio-quickstart-restful-webservice`:
 
 ```scala
-git clone git@github.com:zio/zio-quickstart-restful-webservice.git 
-cd zio-quickstart-restful-webservice
+git clone git@github.com:zio/zio-quickstarts.git 
+cd zio-quickstarts/zio-quickstart-restful-webservice
 ```
 
 Once you are inside the project directory, run the application:


### PR DESCRIPTION
It was written as if each quickstart was in its own repo, but they are not. Also, if you follow the instructions you end up with build products in the individual sub-project directories that are not ignored by git, so I fixed that too.