### PR TITLE
Make zio-quickstart-hello-world work the way README.md says it should

### DIFF
--- a/zio-quickstart-hello-world/build.sbt
+++ b/zio-quickstart-hello-world/build.sbt
@@ -1,4 +1,6 @@
-lazy val `zio-quickstart-hello-world` =
-  project
-    .settings(stdSettings())
-    .settings(enableZIO())
+scalaVersion := "2.13.8"
+organization := "dev.zio"
+
+libraryDependencies ++= Seq(
+  "dev.zio" %% "zio" % "2.0.13"
+)


### PR DESCRIPTION
The old build.sbt file did not work if you cd-ed into the zio-quickstart-hellow-world directory and ran `sbt run`. Now, it does.